### PR TITLE
Added support for stickers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv
 .breakpoints
 replit.nix
 .replit
+.env

--- a/config.json
+++ b/config.json
@@ -1,0 +1,8 @@
+{
+    "stickers": [
+        {
+            "name": "beelau",
+            "image_url": "https://96lb.ml/beelau"
+        }
+    ]
+}

--- a/toes/stickers.py
+++ b/toes/stickers.py
@@ -1,0 +1,34 @@
+import os, json
+from discord import app_commands as slash, Interaction
+from discord.app_commands import Group
+from util.debug import DEBUG_GUILD
+from util.config import CONFIG_PATH, load_sticker_config
+
+DEBUG = True
+
+class Stickers(Group):
+    '''Command group used to hold all sticker commands. Commands are injected
+    via generate_and_inject_sticker_command() inside setup().'''
+
+def setup(tree):
+    '''Sets up Stickers command group from config file.'''
+
+    stickers = Stickers()
+
+    def generate_and_inject_sticker_command(name: str, image_url: str):
+        '''Generates a generic sticker commmand and injects it into the specified
+        command group.'''
+
+        async def base_command(interaction: Interaction):
+            await interaction.response.send_message(image_url)
+
+        command = slash.command()(base_command)
+        setattr(command, 'name', name)
+        stickers._children[name] = command
+        setattr(stickers, name, command) 
+
+    sticker_configs = load_sticker_config()
+    for sticker_config in sticker_configs:
+        generate_and_inject_sticker_command(sticker_config['name'], sticker_config['image_url'])
+
+    tree.add_command(stickers, guild=(DEBUG_GUILD if DEBUG else None))

--- a/util/config.py
+++ b/util/config.py
@@ -1,0 +1,10 @@
+import os, json
+
+CONFIG_PATH = os.path.join(os.getcwd(), 'config.json') 
+
+def load_sticker_config():
+    '''Loads and returns list of sticker configs from config.json.'''
+
+    with open(CONFIG_PATH, 'r') as file:
+        config = json.loads(file.read())
+        return config['stickers']


### PR DESCRIPTION
Chose to dynamically generate sticker commands to make adding/changing them easier to do and maintain. Currently, they are specified in config.json (intent is that this file could be used for other configuration needs except for secrets, of course). Future features could include storing sticker configs in a (simple) database and creating/modifying stickers via commands.

Someone please run this locally (I added "beelau" as a sticker to test with) because I don't trust my code :)

Feel free to leave comments using the built-in code review tool if you think something can be improved.

Also, ignore the forced-pushed messages because those are just due to squashing commits.