### PR TITLE
Refactor trigger system

### DIFF
--- a/config.jason
+++ b/config.jason
@@ -21,26 +21,26 @@
         "keyword_phrase_response": [
             {
                 "keyword": "kyoyo",
-                "phrase_response": "I love feet 😍",
+                "response": "I love feet 😍",
                 "probability": 0.5
             },
             {
                 "keyword": "💀",
-                "phrase_response": "💀",
+                "response": "💀",
                 "probability": 0.5
             }
         ],
         "keyword_reaction_response": [
             {
                 "keyword": "💀",
-                "emoji_name": "💀",
-                "is_custom_emoji": false,
+                "emoji": "💀",
                 "probability": 1.0
-            },
+            }
+        ],
+        "keyword_reaction_response_custom": [
             {
                 "keyword": "grave",
-                "emoji_name": "gravestone",
-                "is_custom_emoji": true,
+                "emoji_id": 984167533777129502,
                 "probability": 1.0
             }
         ]

--- a/config.jason
+++ b/config.jason
@@ -17,32 +17,30 @@
         }
     ],
 
-    "triggers": {
-        "keyword_phrase_response": [
-            {
-                "keyword": "kyoyo",
-                "response": "I love feet 😍",
-                "probability": 0.5
-            },
-            {
-                "keyword": "💀",
-                "response": "💀",
-                "probability": 0.5
-            }
-        ],
-        "keyword_reaction_response": [
-            {
-                "keyword": "💀",
-                "emoji": "💀",
-                "probability": 1.0
-            }
-        ],
-        "keyword_reaction_response_custom": [
-            {
-                "keyword": "grave",
-                "emoji_id": 984167533777129502,
-                "probability": 1.0
-            }
-        ]
-    }
+    "triggers": [
+        {
+            "type": "keyword_response",
+            "keyword": "kyoyo",
+            "response": "I love feet 😍",
+            "probability": 0.5
+        },
+        {
+            "type": "keyword_response",
+            "keyword": "💀",
+            "response": "💀",
+            "probability": 0.5
+        },
+        {
+            "type": "keyword_reaction_standard",
+            "keyword": "💀",
+            "emoji": "💀",
+            "probability": 1.0
+        },
+        {
+            "type": "keyword_reaction_custom",
+            "keyword": "grave",
+            "emoji_id": 984167533777129502,
+            "probability": 1.0
+        }
+    ]
 }

--- a/core/bot.py
+++ b/core/bot.py
@@ -3,7 +3,6 @@ from importlib import import_module
 from util.bot import set_status
 from util.debug import DEBUG_GUILD
 from util.settings import Env
-from extras.triggers import TriggerManager
 
 #set up the discord client
 intents = discord.Intents().default()
@@ -24,7 +23,7 @@ async def on_ready():
         await set_status(bot, f'loading {toe} toe...')
         try:
             module = import_module(f'toes.{toe}')
-            module.setup(tree)
+            module.setup(bot, tree)
         except Exception as e:
             await set_status(bot, f'failed to load {toe} toe!')
             raise e
@@ -35,15 +34,6 @@ async def on_ready():
 
     #notifies that the bot is ready
     await set_status(bot, 'with feet')
-
-@bot.event
-async def on_message(message: discord.Message):
-    # ignore messages sent by the bot (prevents potential infinite loops)
-    if message.author == bot.user:
-        return
-    if message.guild.id == DEBUG_GUILD.id: #todo: change this
-        await TriggerManager.process_message_all(message)
-
 
 def run():
     '''Runs this module.'''

--- a/core/web.py
+++ b/core/web.py
@@ -1,11 +1,11 @@
 from flask import Flask
-from flask.typing import ResponseReturnType
+from flask.typing import ResponseReturnValue
 from threading import Thread
 
-app = Flask('Kyoyobot')
+app: Flask = Flask('Kyoyobot')
 
 @app.route('/')
-def route_index() -> ResponseReturnType:
+def route_index() -> ResponseReturnValue:
     '''Receives pings to keep the server running.'''
     
     return '🐛'

--- a/toes/pinky.py
+++ b/toes/pinky.py
@@ -1,4 +1,4 @@
-from discord import app_commands as slash, Interaction
+from discord import app_commands as slash, Interaction, Client
 from util.debug import DEBUG_GUILD
 
 DEBUG = False
@@ -9,7 +9,7 @@ async def ping(interaction: Interaction) -> None:
     
     await interaction.response.send_message('feet')
 
-def setup(tree: slash.CommandTree) -> None:
-    '''Sets up this command group.'''
+def setup(bot: Client, tree: slash.CommandTree) -> None:
+    '''Sets up this bot module.'''
 
     tree.add_command(ping, guild=(DEBUG_GUILD if DEBUG else None))

--- a/toes/stickers.py
+++ b/toes/stickers.py
@@ -1,4 +1,4 @@
-from discord import app_commands as slash, Interaction
+from discord import app_commands as slash, Interaction, Client
 from discord.errors import HTTPException
 from discord.app_commands.errors import CommandAlreadyRegistered
 from util.debug import DEBUG_GUILD, error
@@ -24,8 +24,8 @@ def add_sticker_command(group: slash.Group, name: str, url: str, description: st
         
         return False
     
-def setup(tree: slash.CommandTree) -> None:
-    '''Sets up this command group.'''
+def setup(bot: Client, tree: slash.CommandTree) -> None:
+    '''Sets up this bot module.'''
 
     stickers = slash.Group(name='stickers', description='Posts stickers from a preset collection.')
 

--- a/toes/triggers.py
+++ b/toes/triggers.py
@@ -146,9 +146,8 @@ def setup(bot: Client, tree: slash.CommandTree) -> None:
 
     async def trigger(bot: Client, message: Message): ...
 
-    #pulls trigger information from the
+    #pulls trigger information from the configuration file
     for trigger_info in Config.get('triggers', []):
-        #determine the type of trigger to create
         trigger_type = trigger_info.get('type')
         trigger_factory = jason_trigger_types.get(trigger_type)
 

--- a/toes/triggers.py
+++ b/toes/triggers.py
@@ -1,9 +1,10 @@
-from typing import Callable, Awaitable, List, Dict, TypeVar
-from discord import Message
 import random
-
-import discord
+from discord import app_commands as slash, Message, Client
+from typing import Callable, Awaitable, List, Dict, TypeVar
+from util.debug import DEBUG_GUILD
 from util.settings import Config
+
+DEBUG = True
 
 class Trigger:
     '''Provides generic functionality for triggers.'''
@@ -116,4 +117,13 @@ class TriggerManager:
         for trigger in TriggerManager._triggers:
             await trigger.process_message(message)
 
-TriggerManager.load_from_config()
+def setup(bot: Client, tree: slash.CommandTree) -> None:
+    '''Sets up this bot module.'''
+    
+    @bot.event
+    async def on_message(message: Message) -> None:
+        # ignore messages sent by the bot (prevents potential infinite loops)
+        if message.author == bot.user:
+            return
+        if not DEBUG or message.guild.id == DEBUG_GUILD.id: #todo: change this
+            await TriggerManager.process_message_all(message)

--- a/toes/triggers.py
+++ b/toes/triggers.py
@@ -80,57 +80,29 @@ class KeywordTrigger():
 
         return if_keyword(keyword)(with_probability(probability)((lambda x, y: '') if is_custom_emoji else trigger_reaction_standard(emoji_name)))
 
-class TriggerManager:
-    '''Stores and manages all trigger instances.'''
 
-    _triggers: Trigger = trigger_null()
-
-    @classmethod
-    def load_from_config(cls) -> None:
-        '''Loads all triggers from config.'''
-
-        TriggerManager._load_keyword_phrase_response_triggers_from_config()
-        TriggerManager._load_keyword_reaction_response_triggers_from_config()
-
-    @classmethod
-    def _load_keyword_phrase_response_triggers_from_config(cls) -> None:
-        '''Loads keyword_phrase_response triggers from config and adds them.'''
-
-        triggers: Dict = Config.get('triggers')
-        keyword_phrase_response_triggers = triggers.get('keyword_phrase_response', [])
-        for trigger_info in keyword_phrase_response_triggers:
-            TriggerManager.add_trigger(KeywordTrigger.from_phrase_response(**trigger_info))
-
-    @classmethod
-    def _load_keyword_reaction_response_triggers_from_config(cls) -> None:
-        '''Loads keyword_reaction_response triggers from config and adds them.'''
-
-        triggers: Dict = Config.get('triggers')
-        keyword_reaction_response_triggers = triggers.get('keyword_reaction_response', [])
-        for trigger_info in keyword_reaction_response_triggers:
-            TriggerManager.add_trigger(KeywordTrigger.from_reaction_response(**trigger_info))
-
-    @classmethod
-    def add_trigger(cls, trigger: Trigger) -> None:
-        '''Adds a trigger.'''
-
-        TriggerManager._triggers = after_trigger(TriggerManager._triggers)(trigger)
-
-    @classmethod
-    async def process_message_all(cls, bot: Client, message: Message) -> None:
-        '''Processes all triggers.'''
-
-        await cls._triggers(bot, message)
 
 def setup(bot: Client, tree: slash.CommandTree) -> None:
     '''Sets up this bot module.'''
 
-    TriggerManager.load_from_config()
+    trigger: Trigger = trigger_null()
+
+    trigger_config : Dict[str, str] = Config.get('triggers')
+
+    keyword_phrase_response_triggers = trigger_config.get('keyword_phrase_response', [])
+    for trigger_info in keyword_phrase_response_triggers:
+        trigger = after_trigger(trigger)(KeywordTrigger.from_phrase_response(**trigger_info))
+
+    keyword_reaction_response_triggers = trigger_config.get('keyword_reaction_response', [])
+    for trigger_info in keyword_reaction_response_triggers:
+        trigger = after_trigger(trigger)(KeywordTrigger.from_reaction_response(**trigger_info))
+
     
     @bot.event
     async def on_message(message: Message) -> None:
         # ignore messages sent by the bot (prevents potential infinite loops)
         if message.author == bot.user:
             return
-        if not DEBUG or message.guild.id == DEBUG_GUILD.id: #todo: change this
-            await TriggerManager.process_message_all(bot, message)
+        
+        if not DEBUG or (message.guild is not None and message.guild.id == DEBUG_GUILD.id): #todo: change this
+            await trigger(bot, message)

--- a/util/settings.py
+++ b/util/settings.py
@@ -10,8 +10,7 @@ class Settings(ABC):
     
     @property
     @abstractmethod
-    def SETTINGS_FILE(self) -> str:
-        pass
+    def SETTINGS_FILE(self) -> str: ...
 
     @classmethod
     @abstractmethod


### PR DESCRIPTION
Updates the architecture for building triggers to make it more generic and extensible. Notable changes include:

* Triggers are now represented as functions instead of classes, allowing for easy composability
* Triggers can be modified and extended through the use of decorators
* The config.jason file can access trigger factory functions from the code with the use of type labels
* The structure of config.jason's trigger field has been flattened
* Reacting with standard and custom emoji are now two separate events due to requiring different input parameters
* As a 'toe' now includes non-slash-command functionality, the setup function now has access to the bot

Feel free to dive into closure purgatory by going through the commit history to see how each piece of the old system was converted into the new one.