### PR TITLE
Overhaul trigger system (again)

### DIFF
--- a/config.jason
+++ b/config.jason
@@ -19,9 +19,11 @@
 
     "triggers": [
         {
-            "type": "keyword_random_response",
+            "type": "if_keyword with_probability pick_random",
             "keyword": "\\?$",
-            "responses": [
+            "probability": 10,
+            "r_type": "action_send_response",
+            "r_args": [
                 "yeah",
                 "yes",
                 "ye",
@@ -29,8 +31,7 @@
                 "no",
                 "nope",
                 "?"
-            ],
-            "probability": 10
+            ]
         },
         {
             "type": "with_probability action_send_response",
@@ -56,10 +57,11 @@
             "emoji_id": 941354051059208222
         },
         {
-            "type": "random_emoji_thing",
+            "type": "if_keyword with_probability pick_random",
             "keyword": "\\b(slovak(ia(n)?)?|svk)\\b|🇸🇰",
             "probability": 20,
-            "emojis": [
+            "r_type": "action_react_standard",
+            "r_args": [
                 "🇸🇮",
                 "🇷🇸",
                 "🇨🇿",

--- a/config.jason
+++ b/config.jason
@@ -47,10 +47,22 @@
             "text": "💀"
         },
         {
+            "type": "if_keyword if_lucky do_text",
+            "keyword": "```",
+            "probability": 5,
+            "text": "https://cdn.discordapp.com/emojis/981421960879812618.webp"
+        },
+        {
             "type": "if_keyword if_lucky do_react",
             "keyword": "💀",
             "probability": 10,
             "emoji": "💀"
+        },
+        {
+            "type": "if_keyword if_lucky do_react_custom",
+            "keyword": "xf|fail",
+            "probability": 20,
+            "emoji_id": 981421960879812618
         },
         {
             "type": "if_keyword if_lucky do_react_custom",
@@ -113,16 +125,6 @@
             "author_id": 734540120329289840,
             "probability": 0.5,
             "emoji_id": 968369877901541426
-        },
-        {
-            "type": "if_keyword do_text do_another",
-            "keyword": "1",
-            "text": "2",
-            "other": {
-                "type": "if_keyword do_text",
-                "keyword": "3",
-                "text": "4"
-            }
         }
     ]
 }

--- a/config.jason
+++ b/config.jason
@@ -33,10 +33,9 @@
             "probability": 10
         },
         {
-            "type": "action_send_response",
-            "keyword": "",
-            "response": "I love feet 😍",
-            "probability": 0.1
+            "type": "with_probability action_send_response",
+            "probability": 50,
+            "response": "I love feet 😍"
         },
         {
             "type": "keyword_response",

--- a/config.jason
+++ b/config.jason
@@ -22,8 +22,8 @@
             "type": "if_keyword if_lucky do_random",
             "keyword": "\\?$",
             "probability": 10,
-            "r_type": "do_text",
-            "r_args": {
+            "choices": {
+                "type": "do_text",
                 "text": [
                     "yeah",
                     "yes",
@@ -62,8 +62,8 @@
             "type": "if_keyword if_lucky do_random",
             "keyword": "\\b(slovak(ia(n)?)?|svk)\\b|🇸🇰",
             "probability": 20,
-            "r_type": "do_react",
-            "r_args": {
+            "choices": {
+                "type": "do_react",
                 "emoji": [
                     "🇸🇮",
                     "🇷🇸",

--- a/config.jason
+++ b/config.jason
@@ -33,7 +33,7 @@
             "probability": 10
         },
         {
-            "type": "keyword_response",
+            "type": "action_send_response",
             "keyword": "",
             "response": "I love feet 😍",
             "probability": 0.1

--- a/config.jason
+++ b/config.jason
@@ -19,10 +19,10 @@
 
     "triggers": [
         {
-            "type": "if_keyword with_probability pick_random",
+            "type": "if_keyword if_lucky do_random",
             "keyword": "\\?$",
             "probability": 10,
-            "r_type": "action_send_response",
+            "r_type": "do_text",
             "r_args": {
                 "response": [
                     "yeah",
@@ -36,33 +36,33 @@
             }
         },
         {
-            "type": "with_probability action_send_response",
+            "type": "if_lucky do_text",
             "probability": 0.1,
             "response": "I love feet 😍"
         },
         {
-            "type": "if_keyword with_probability action_send_response",
+            "type": "if_keyword if_lucky do_text",
             "keyword": "💀",
             "probability": 5,
             "response": "💀"
         },
         {
-            "type": "if_keyword with_probability action_react_standard",
+            "type": "if_keyword if_lucky do_react",
             "keyword": "💀",
             "probability": 10,
             "emoji": "💀"
         },
         {
-            "type": "if_keyword with_probability action_react_custom",
+            "type": "if_keyword if_lucky do_react_custom",
             "keyword": "\\bbeelau\\b",
             "probability": 20,
             "emoji_id": 941354051059208222
         },
         {
-            "type": "if_keyword with_probability pick_random",
+            "type": "if_keyword if_lucky do_random",
             "keyword": "\\b(slovak(ia(n)?)?|svk)\\b|🇸🇰",
             "probability": 20,
-            "r_type": "action_react_standard",
+            "r_type": "do_react",
             "r_args": {
                 "emoji": [
                     "🇸🇮",
@@ -73,43 +73,43 @@
             }
         },
         {
-            "type": "if_author with_probability action_react_standard",
+            "type": "if_author if_lucky do_react",
             "author_id": 757355879975747587,
             "probability": 0.25,
             "emoji": "🦓"
         },
         {
-            "type": "if_author with_probability action_react_custom",
+            "type": "if_author if_lucky do_react_custom",
             "author_id": 757355879975747587,
             "probability": 0.25,
             "emoji_id": 944384071654580266
         },
         {
-            "type": "if_author with_probability action_react_custom",
+            "type": "if_author if_lucky do_react_custom",
             "author_id": 285167387278442506,
             "probability": 0.25,
             "emoji_id": 968582865442967582
         },
         {
-            "type": "if_author with_probability action_react_custom",
+            "type": "if_author if_lucky do_react_custom",
             "author_id": 285167387278442506,
             "probability": 0.25,
             "emoji_id": 979140176318169108
         },
         {
-            "type": "if_author with_probability action_react_custom",
+            "type": "if_author if_lucky do_react_custom",
             "author_id": 236257776421175296,
             "probability": 0.5,
             "emoji_id": 936482360290050069
         },
         {
-            "type": "if_author with_probability action_react_custom",
+            "type": "if_author if_lucky do_react_custom",
             "author_id": 336919720550989824,
             "probability": 0.5,
             "emoji_id": 941354051059208222
         },
         {
-            "type": "if_author with_probability action_react_custom",
+            "type": "if_author if_lucky do_react_custom",
             "author_id": 734540120329289840,
             "probability": 0.5,
             "emoji_id": 968369877901541426

--- a/config.jason
+++ b/config.jason
@@ -23,15 +23,17 @@
             "keyword": "\\?$",
             "probability": 10,
             "r_type": "action_send_response",
-            "r_args": [
-                "yeah",
-                "yes",
-                "ye",
-                "nah",
-                "no",
-                "nope",
-                "?"
-            ]
+            "r_args": {
+                "response": [
+                    "yeah",
+                    "yes",
+                    "ye",
+                    "nah",
+                    "no",
+                    "nope",
+                    "?"
+                ]
+            }
         },
         {
             "type": "with_probability action_send_response",
@@ -61,12 +63,14 @@
             "keyword": "\\b(slovak(ia(n)?)?|svk)\\b|🇸🇰",
             "probability": 20,
             "r_type": "action_react_standard",
-            "r_args": [
-                "🇸🇮",
-                "🇷🇸",
-                "🇨🇿",
-                "🇷🇺"
-            ]
+            "r_args": {
+                "emoji": [
+                    "🇸🇮",
+                    "🇷🇸",
+                    "🇨🇿",
+                    "🇷🇺"
+                ]
+            }
         },
         {
             "type": "if_author with_probability action_react_standard",

--- a/config.jason
+++ b/config.jason
@@ -34,79 +34,79 @@
         },
         {
             "type": "with_probability action_send_response",
-            "probability": 50,
+            "probability": 0.1,
             "response": "I love feet 😍"
         },
         {
-            "type": "keyword_response",
+            "type": "if_keyword with_probability action_send_response",
             "keyword": "💀",
-            "response": "💀",
-            "probability": 5
+            "probability": 5,
+            "response": "💀"
         },
         {
-            "type": "keyword_reaction_standard",
+            "type": "if_keyword with_probability action_react_standard",
             "keyword": "💀",
-            "emoji": "💀",
-            "probability": 10
+            "probability": 10,
+            "emoji": "💀"
         },
         {
-            "type": "keyword_reaction_custom",
+            "type": "if_keyword with_probability action_react_custom",
             "keyword": "\\bbeelau\\b",
-            "emoji_id": 941354051059208222,
-            "probability": 20
+            "probability": 20,
+            "emoji_id": 941354051059208222
         },
         {
-            "type": "keyword_reaction_random",
+            "type": "random_emoji_thing",
             "keyword": "\\b(slovak(ia(n)?)?|svk)\\b|🇸🇰",
+            "probability": 20,
             "emojis": [
                 "🇸🇮",
                 "🇷🇸",
                 "🇨🇿",
                 "🇷🇺"
-            ],
-            "probability": 20
+            ]
         },
         {
-            "type": "user_reaction_standard",
+            "type": "if_author with_probability action_react_standard",
             "author_id": 757355879975747587,
-            "emoji": "🦓",
-            "probability": 0.25
+            "probability": 0.25,
+            "emoji": "🦓"
         },
         {
-            "type": "user_reaction_custom",
+            "type": "if_author with_probability action_react_custom",
             "author_id": 757355879975747587,
-            "emoji_id": 944384071654580266,
-            "probability": 0.25
+            "probability": 0.25,
+            "emoji_id": 944384071654580266
         },
         {
-            "type": "user_reaction_custom",
+            "type": "if_author with_probability action_react_custom",
             "author_id": 285167387278442506,
-            "emoji_id": 968582865442967582,
-            "probability": 0.25
+            "probability": 0.25,
+            "emoji_id": 968582865442967582
         },
         {
-            "type": "user_reaction_custom",
+            "type": "if_author with_probability action_react_custom",
             "author_id": 285167387278442506,
-            "emoji_id": 979140176318169108,
-            "probability": 0.25
+            "probability": 0.25,
+            "emoji_id": 979140176318169108
         },
         {
-            "type": "user_reaction_custom",
+            "type": "if_author with_probability action_react_custom",
             "author_id": 236257776421175296,
-            "emoji_id": 936482360290050069,
-            "probability": 0.5
+            "probability": 0.5,
+            "emoji_id": 936482360290050069
         },
         {
-            "type": "user_reaction_custom",
+            "type": "if_author with_probability action_react_custom",
             "author_id": 336919720550989824,
-            "emoji_id": 941354051059208222,
-            "probability": 0.5
+            "probability": 0.5,
+            "emoji_id": 941354051059208222
         },
         {
-            "type": "user_reaction_custom",
+            "type": "if_author with_probability action_react_custom",
             "author_id": 734540120329289840,
-            "emoji_id": 968369877901541426,
-            "probability": 0.5
+            "probability": 0.5,
+            "emoji_id": 968369877901541426
         }
     ]
 }

--- a/config.jason
+++ b/config.jason
@@ -113,6 +113,16 @@
             "author_id": 734540120329289840,
             "probability": 0.5,
             "emoji_id": 968369877901541426
+        },
+        {
+            "type": "if_keyword do_text do_another",
+            "keyword": "1",
+            "text": "2",
+            "other": {
+                "type": "if_keyword do_text",
+                "keyword": "3",
+                "text": "4"
+            }
         }
     ]
 }

--- a/config.jason
+++ b/config.jason
@@ -53,6 +53,18 @@
             "text": "https://cdn.discordapp.com/emojis/981421960879812618.webp"
         },
         {
+            "type": "if_keyword if_lucky do_text",
+            "keyword": "kyoyo",
+            "probability": 1,
+            "text": "hi"
+        },
+        {
+            "type": "if_keyword if_lucky do_text",
+            "keyword": "\\ba-\\b",
+            "probability": 5,
+            "text": "why not a+?"
+        },
+        {
             "type": "if_keyword if_lucky do_react",
             "keyword": "💀",
             "probability": 10,

--- a/config.jason
+++ b/config.jason
@@ -24,7 +24,7 @@
             "probability": 10,
             "r_type": "do_text",
             "r_args": {
-                "response": [
+                "text": [
                     "yeah",
                     "yes",
                     "ye",
@@ -38,13 +38,13 @@
         {
             "type": "if_lucky do_text",
             "probability": 0.1,
-            "response": "I love feet 😍"
+            "text": "I love feet 😍"
         },
         {
             "type": "if_keyword if_lucky do_text",
             "keyword": "💀",
             "probability": 5,
-            "response": "💀"
+            "text": "💀"
         },
         {
             "type": "if_keyword if_lucky do_react",

--- a/toes/triggers.py
+++ b/toes/triggers.py
@@ -1,7 +1,7 @@
 import random, re
 from discord import app_commands as slash, Client, Message
 from functools import wraps
-from typing import Any, Awaitable, Callable, Coroutine, Optional, Sequence
+from typing import Any, Awaitable, Callable, Coroutine, Mapping, Optional, Sequence
 from util.debug import DEBUG_GUILD, catch, error
 from util.settings import Config
 
@@ -99,7 +99,7 @@ async def action_react_custom(bot: Client, message: Message, trigger: Trigger, *
 ###
 
 @modifier
-async def pick_random(bot: Client, message: Message, trigger: Trigger, *, r_type: str, r_args: Sequence, **kwargs: Any):
+async def pick_random(bot: Client, message: Message, trigger: Trigger, *, r_type: str, r_args: Mapping[str, Sequence], **kwargs: Any):
     '''Applies a random argument from the list to the provided modifier factory.'''
 
     # placeholder definition in case of exception 
@@ -107,8 +107,8 @@ async def pick_random(bot: Client, message: Message, trigger: Trigger, *, r_type
     
     with catch(Exception, f'Triggers :: Failed to execute random trigger of type {r_type} with args {r_args}!'):
         factory: TriggerModifierFactory = modifiers[r_type]
-        modifier: TriggerModifier = factory(random.choice(r_args)) # TODO: things don't take positional args anymore so we need to get the name too
-        modified: Trigger = modifier(trigger) # type: ignore[no-redef]
+        modifier: TriggerModifier = factory(**{key: random.choice(values) for key, values in r_args.items()})
+        modified = modifier(trigger)
 
     await modified(bot, message)
     

--- a/toes/triggers.py
+++ b/toes/triggers.py
@@ -211,7 +211,7 @@ def trigger_user_reaction_custom(*, author_id: int, probability: float = 100, em
 
 ###
 
-async def trigger_null(bot: Client, message: Message) -> None: ...
+async def trigger_null(bot: Client, message: Message, /) -> None: ...
 
 def create_trigger(types : Sequence[str], **kwargs) -> Optional[Trigger]:
     '''Creates a trigger by stacking the specified modifier types.'''

--- a/toes/triggers.py
+++ b/toes/triggers.py
@@ -99,15 +99,16 @@ async def action_react_custom(bot: Client, message: Message, trigger: Trigger, *
 ###
 
 @modifier
-async def pick_random(bot: Client, message: Message, trigger: Trigger, *, factory: TriggerModifierFactory, args: Sequence, **kwargs: Any):
+async def pick_random(bot: Client, message: Message, trigger: Trigger, *, r_type: str, r_args: Sequence, **kwargs: Any):
     '''Applies a random argument from the list to the provided modifier factory.'''
 
     # placeholder definition in case of exception 
-    async def modified(bot: Client, message: Message) -> None: ...
+    modified = trigger_null
     
-    with catch(Exception, f'Triggers :: Failed to execute random trigger {factory}!'):
-        modifier : TriggerModifier = factory(random.choice(args))
-        modified : Trigger = modifier(trigger) # type: ignore[no-redef]
+    with catch(Exception, f'Triggers :: Failed to execute random trigger of type {r_type} with args {r_args}!'):
+        factory: TriggerModifierFactory = modifiers[r_type]
+        modifier: TriggerModifier = factory(random.choice(r_args)) # TODO: things don't take positional args anymore so we need to get the name too
+        modified: Trigger = modifier(trigger) # type: ignore[no-redef]
 
     await modified(bot, message)
     

--- a/toes/triggers.py
+++ b/toes/triggers.py
@@ -100,9 +100,9 @@ async def do_react_custom(bot: Client, message: Message, trigger: Trigger, *, em
 async def do_another(bot: Client, message: Message, trigger: Trigger, *, other: Mapping[str, Any], **kwargs: Any) -> None:
     '''Executes another trigger before this one.'''
 
-    other = create_trigger(**other)
-    if other is not None:
-        await other(bot, message)
+    other_trigger = create_trigger(**other)
+    if other_trigger is not None:
+        await other_trigger(bot, message)
     await trigger(bot, message)
 
 @modifier

--- a/toes/triggers.py
+++ b/toes/triggers.py
@@ -70,11 +70,11 @@ async def do_another(bot: Client, message: Message, trigger: Trigger, *, other: 
     await trigger(bot, message)
 
 @modifier
-async def do_text(bot: Client, message: Message, trigger: Trigger, *, response: str, **kwargs: Any) -> None:
+async def do_text(bot: Client, message: Message, trigger: Trigger, *, text: str, **kwargs: Any) -> None:
     '''Sends a text response in the channel in which the message was received.'''
     
     with catch(Exception, 'Triggers :: Failed to send message!'):
-        await message.channel.send(response)
+        await message.channel.send(text)
     
     await trigger(bot, message)
 

--- a/toes/triggers.py
+++ b/toes/triggers.py
@@ -234,12 +234,7 @@ def setup(bot: Client, tree: slash.CommandTree) -> None:
 
     for trigger_info in trigger_config:
         trigger_type = trigger_info.get('type')
-        trigger_factory = jason_trigger_types.get(trigger_type)
-        
-        # attempt to create the trigger with the appropriate factory method
-        new_trigger : Optional[Trigger] = None
-        with catch(TypeError, f'Triggers :: Failed to create trigger of type {trigger_type}!'):
-            new_trigger = trigger_factory(**trigger_info) # type: ignore
+        new_trigger = create_trigger(trigger_type, **trigger_info)
         
         # combines the triggers
         if new_trigger:

--- a/toes/triggers.py
+++ b/toes/triggers.py
@@ -56,7 +56,7 @@ async def if_author(bot: Client, message: Message, trigger: Trigger, *, author_i
         await trigger(bot, message)
 
 @modifier
-async def with_probability(bot: Client, message: Message, *, trigger: Trigger, probability: float, **kwargs: Any) -> None:
+async def with_probability(bot: Client, message: Message, trigger: Trigger, *, probability: float, **kwargs: Any) -> None:
     '''Executes the trigger with a random probability.'''
     
     if random.random() * 100 <= probability:
@@ -222,7 +222,7 @@ def create_trigger(types : Sequence[str], **kwargs) -> Optional[Trigger]:
         try:
             modifier_factory = modifiers.get(type)
             modifier = modifier_factory(**kwargs) # type: ignore
-            trigger = modifier(trigger) # type: ignore
+            trigger = modifier(trigger)
         except TypeError as e:
             error(e, f'Triggers :: Failed to create trigger of type {types} because of type {type}.')
             return None        

--- a/toes/triggers.py
+++ b/toes/triggers.py
@@ -204,12 +204,28 @@ def trigger_user_reaction_custom(*, author_id: int, probability: float = 100, em
     async def trigger(bot: Client, message: Message): ...
     return trigger
 
+###
+
+async def trigger_null(bot: Client, message: Message) -> None: ...
+
+def create_trigger(types : Sequence[str], **kwargs) -> Optional[Trigger]:
+    
+    trigger = trigger_null
+    
+    for type in reversed(types):
+        with catch(TypeError, f'Triggers :: Failed to create trigger of type {types} because of type {type}.'):
+            trigger_factory = jason_trigger_types.get(type)
+            trigger = trigger_factory(**kwargs)(trigger) # type: ignore
+            return None
+    
+    return trigger
+
 ### SETUP ###
 
 def setup(bot: Client, tree: slash.CommandTree) -> None:
     '''Sets up this bot module.'''
 
-    async def trigger(__bot: Client, __message: Message) -> None: ...
+    trigger = trigger_null
 
     # pulls trigger information from the configuration file
     trigger_config = []
@@ -227,7 +243,7 @@ def setup(bot: Client, tree: slash.CommandTree) -> None:
         
         # combines the triggers
         if new_trigger:
-            trigger = action_trigger(trigger)(new_trigger)
+            trigger = action_trigger(trigger)(new_trigger) # type: ignore
     
     @bot.event
     async def on_message(message: Message) -> None:


### PR DESCRIPTION
Closes #19 

The changes are pretty much described in the above issue. Instead of having hardcoded trigger types, the individual modifiers are now directly exposed in `config.jason` and can be stacked at will, allowing for far greater flexibility without the need to constantly add more bloat to `toes/triggers.py`. As a result, most of the modifiers have been renamed and the system for modifiers which call other triggers has been reworked. I also added a few new triggers because I do that with every trigger update and L to separating the commits.