### PR TITLE
Added say command, added more responses in ask command, and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Kyoyobot
 🐛
+This is a discord bot.

--- a/toes/big_toe.py
+++ b/toes/big_toe.py
@@ -1,0 +1,30 @@
+import random
+from discord import app_commands as slash, Client, Interaction, TextChannel
+from util.debug import DEBUG_GUILD
+
+DEBUG = False
+
+@slash.command()
+async def say(interaction: Interaction, channel: TextChannel, message:str,) -> None:
+    '''Have Kyoyobot say something in a channel.'''
+    
+    text = f'You told me to say \"{message}\" in {channel.name}\n'
+    await channel.send(message)
+    await interaction.response.send_message(text)
+    
+
+#@say.autocomplete('channel')
+#async def channels_autocomplete(interaction: Interaction, current: str) -> list[slash.Choice[str]]:
+#    channels = []
+#    for item in Client.get_all_channels():
+#        channels.append(item)
+#    return [slash.Choice(name=channel, value=channel) for channel in channels if current.lower() in channel.name]
+
+
+
+
+def setup(bot: Client, tree: slash.CommandTree) -> None:
+    '''Sets up this bot module.'''
+
+    tree.add_command(say, guild=(DEBUG_GUILD if DEBUG else None))
+

--- a/toes/extra_toe.py
+++ b/toes/extra_toe.py
@@ -7,10 +7,10 @@ DEBUG = False
 # This command will have the bot send a message to a specified text channel 
 # bot will announce the user who initiated the command in the current channel
 @slash.command()
-async def say(interaction: Interaction, channel: TextChannel, message:str,) -> None:
+async def say(interaction: Interaction, channel: TextChannel, message: str) -> None:
     '''Have Kyoyobot say something in a channel.'''
     
-    text = f'{interaction.user} told me to say \"{message}\" in #{channel.name}\n'
+    text = f'{interaction.user.mention} told me to say \"{message}\" in #{channel.mention}\n'
     await channel.send(message)
     await interaction.response.send_message(text) 
     

--- a/toes/extra_toe.py
+++ b/toes/extra_toe.py
@@ -4,13 +4,15 @@ from util.debug import DEBUG_GUILD
 
 DEBUG = False
 
+# This command will have the bot send a message to a specified text channel 
+# bot will announce the user who initiated the command in the current channel
 @slash.command()
 async def say(interaction: Interaction, channel: TextChannel, message:str,) -> None:
     '''Have Kyoyobot say something in a channel.'''
     
-    text = f'You told me to say \"{message}\" in #{channel.name}\n'
+    text = f'{interaction.user} told me to say \"{message}\" in #{channel.name}\n'
     await channel.send(message)
-    await interaction.response.send_message(text)
+    await interaction.response.send_message(text) 
     
 
 def setup(bot: Client, tree: slash.CommandTree) -> None:

--- a/toes/extra_toe.py
+++ b/toes/extra_toe.py
@@ -13,16 +13,6 @@ async def say(interaction: Interaction, channel: TextChannel, message:str,) -> N
     await interaction.response.send_message(text)
     
 
-#@say.autocomplete('channel')
-#async def channels_autocomplete(interaction: Interaction, current: str) -> list[slash.Choice[str]]:
-#    channels = []
-#    for item in Client.get_all_channels():
-#        channels.append(item)
-#    return [slash.Choice(name=channel, value=channel) for channel in channels if current.lower() in channel.name]
-
-
-
-
 def setup(bot: Client, tree: slash.CommandTree) -> None:
     '''Sets up this bot module.'''
 

--- a/toes/extra_toe.py
+++ b/toes/extra_toe.py
@@ -8,7 +8,7 @@ DEBUG = False
 async def say(interaction: Interaction, channel: TextChannel, message:str,) -> None:
     '''Have Kyoyobot say something in a channel.'''
     
-    text = f'You told me to say \"{message}\" in {channel.name}\n'
+    text = f'You told me to say \"{message}\" in #{channel.name}\n'
     await channel.send(message)
     await interaction.response.send_message(text)
     

--- a/toes/extra_toe.py
+++ b/toes/extra_toe.py
@@ -10,7 +10,7 @@ DEBUG = False
 async def say(interaction: Interaction, channel: TextChannel, message: str) -> None:
     '''Have Kyoyobot say something in a channel.'''
     
-    text = f'{interaction.user.mention} told me to say \"{message}\" in #{channel.mention}\n'
+    text = f'{interaction.user.mention} told me to say \"{message}\" in {channel.mention}\n'
     await channel.send(message)
     await interaction.response.send_message(text) 
     

--- a/toes/pinky.py
+++ b/toes/pinky.py
@@ -42,7 +42,7 @@ async def ask(interaction: Interaction, question: str) -> None:
         'My sources say no.',
         'Outlook not so good.',
         'Very doubtful.',
-	    'Kyoyo says no', 
+        'Kyoyo says no',
         'My toesies don\'t tingle :('
 
     ]

--- a/toes/pinky.py
+++ b/toes/pinky.py
@@ -27,19 +27,23 @@ async def ask(interaction: Interaction, question: str) -> None:
         'Outlook good.',
         'Yes.',
         'Signs point to yes.',
+        'My toes point to yes.', 
+        'My toesies are tingling, yes!', 
         # Neutral
         'Reply hazy, try again.',
         'Ask again later.',
         'Better not tell you now.',
         'Cannot predict now.',
         'Concentrate and ask again.',
+        'Offer more feet and try again.',
         # Negative
         'Don\'t count on it.',
         'My reply is no.',
         'My sources say no.',
         'Outlook not so good.',
         'Very doubtful.',
-	'Kyoyo says no'
+	    'Kyoyo says no', 
+        'My toesies don\'t tingle :('
 
     ]
 


### PR DESCRIPTION
`/say` command will have kyoyobot say a message in a specified channel. Kyoyobot will also announce which user told it to say the message in the current channel. 

Added more funny responses in the `/ask` command.

README also updated to specify this repo is a discord bot.