### PR TITLE
Add links command

### DIFF
--- a/config.jason
+++ b/config.jason
@@ -21,6 +21,19 @@
             "description": "a picture of a tall white rectangle"
         }
     ],
+    
+    "links": [
+        {
+            "name": "github",
+            "url": "https://github.com/96-LB/Kyoyobot",
+            "description": "please submit a pr"
+        },
+        {
+            "name": "kyoyoland",
+            "url": "https://discord.gg/JFHk6QpPVS",
+            "description": "the official \"support\" server (you will find no support)"
+        }
+    ],
 
     "triggers": [
         {

--- a/toes/links.py
+++ b/toes/links.py
@@ -1,0 +1,38 @@
+from discord import app_commands as slash, Client, Interaction
+from discord.errors import HTTPException
+from discord.app_commands.errors import CommandAlreadyRegistered
+from util.debug import DEBUG_GUILD, catch
+from util.settings import Config
+
+DEBUG = False
+
+def add_link_command(group: slash.Group, name: str, url: str, description: str = '') -> None:
+    '''Generates a link commmand and adds it to the specified command group.'''
+
+    
+    description = str(description or f'Posts a link to {name}.')
+
+    # attempt to add the command and return whether it succeeded
+    with catch((HTTPException, TypeError, CommandAlreadyRegistered), f'Links :: Failed to add {name} link!'):
+        @group.command(name=name, description=description)
+        async def _(interaction: Interaction) -> None:
+            await interaction.response.send_message(str(url), ephemeral=True)
+    
+def setup(bot: Client, tree: slash.CommandTree) -> None:
+    '''Sets up this bot module.'''
+
+    links = slash.Group(name='links', description='A quick reference of useful links.')
+
+    # load each link command from the configuration file
+    link_configs = []
+    with catch(TypeError, 'Links :: Failed to load link configuration!'):
+        link_configs = list(Config.get('links')) # type: ignore
+    
+    for link_config in link_configs:
+        name = link_config.get('name')
+        url = link_config.get('url')
+        description = link_config.get('description')
+        
+        add_link_command(links, name, url, description)
+
+    tree.add_command(links, guild=(DEBUG_GUILD if DEBUG else None))

--- a/util/settings.py
+++ b/util/settings.py
@@ -52,7 +52,7 @@ def json_settings(filename: str) -> Settings:
     with catch((json.decoder.JSONDecodeError, FileNotFoundError),
                f'Settings :: Failed to load JSON data from {filename}!'):
 
-        with open(filename) as file:
+        with open(filename, encoding='utf8') as file:
             obj = json.loads(file.read())
 
             # force result to be a dictionary


### PR DESCRIPTION
For important links such as the GitHub page and the support/testing server. Right now it's literally a clone of the `stickers` command (except with ephemeral messages), but that may change in an upcoming refactor.